### PR TITLE
Change location from eastus to centralus

### DIFF
--- a/src/terraform/terraform.tfvars
+++ b/src/terraform/terraform.tfvars
@@ -19,7 +19,7 @@
 # deployment (afdblobbic) so both can coexist in the same subscription.
 workload_name    = "afdblobtf"
 environment_name = "dev"
-location         = "eastus"
+location         = "centralus"
 
 # ---------------------------------------------------------------------------
 # Networking


### PR DESCRIPTION
This pull request makes a small update to the Terraform configuration by changing the deployment location from "eastus" to "centralus" in the `terraform.tfvars` file. This will affect where the resources are provisioned in Azure.