### PR TITLE
Update parameters for development environment

### DIFF
--- a/src/bicep/parameters/main.dev.bicepparam
+++ b/src/bicep/parameters/main.dev.bicepparam
@@ -12,37 +12,28 @@
 using '../main.bicep'
 
 // ── Identity ──────────────────────────────────────────────────────────────────
-
-@description('Short workload identifier (no hyphens, 2–10 chars).')
 // Suffix "bic" differentiates Bicep-deployed resources from the Terraform
 // deployment (afdblobtf) so both can coexist in the same subscription.
 param workloadName = 'afdblobbic'
 
-@description('Deployment environment.')
 param environmentName = 'dev'
 
-@description('Short code for East US 2.')
-param locationShort = 'eus2'
+param locationShort = 'centralus'
 
 // ── Networking ────────────────────────────────────────────────────────────────
 
-@description('VNet address space for dev.')
 param vnetAddressPrefix = '10.0.0.0/16'
 
-@description('Subnet CIDR dedicated to private endpoints in dev.')
 param privateEndpointSubnetPrefix = '10.0.1.0/24'
 
 // ── Storage ───────────────────────────────────────────────────────────────────
 
-@description('Standard_LRS is sufficient for dev (no geo-redundancy required).')
 param storageSkuName = 'Standard_LRS'
 
 // ── Monitoring ────────────────────────────────────────────────────────────────
 
-@description('30-day retention is appropriate for dev; reduce cost.')
 param logRetentionInDays = 30
 
 // ── Security ──────────────────────────────────────────────────────────────────
 
-@description('Minimum soft-delete window; lower values ease dev teardown.')
 param kvSoftDeleteRetentionInDays = 7


### PR DESCRIPTION
This pull request makes minor updates to the `main.dev.bicepparam` file, primarily adjusting deployment parameters for the development environment. The most notable change is switching the deployment location from East US 2 to Central US.

- **Deployment Environment Update:**
  - Changed the `locationShort` parameter value from `'eus2'` (East US 2) to `'centralus'` to deploy resources in Central US instead of East US 2.

- **Parameter Documentation Cleanup:**
  - Removed all `@description` annotations from parameter declarations to simplify the parameter file.