### PR TITLE
Shorten locationShort parameter value

### DIFF
--- a/src/bicep/parameters/main.dev.bicepparam
+++ b/src/bicep/parameters/main.dev.bicepparam
@@ -18,7 +18,7 @@ param workloadName = 'afdblobbic'
 
 param environmentName = 'dev'
 
-param locationShort = 'centralus'
+param locationShort = 'cus'
 
 // ── Networking ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
This pull request makes a minor update to the `main.dev.bicepparam` parameters file, changing the value of the `locationShort` parameter to use a shorter code for the Central US region. This helps standardize location codes across the deployment scripts.